### PR TITLE
Gracefully handle missing page data from Drupal

### DIFF
--- a/components/BasicPage.vue
+++ b/components/BasicPage.vue
@@ -57,6 +57,7 @@
 </template>
 
 <script>
+import _ from "lodash";
 import CalloutCard from "~/components/CalloutCard";
 import CardDeck from "~/components/CardDeck";
 import FeatureStack from "~/components/FeatureStack";
@@ -85,9 +86,9 @@ export default {
     VideoBlock
   },
   props: {
-    body: {
-      type: String,
-      default: ""
+    pageData: {
+      type: Object,
+      default: null
     },
     extendedContent: {
       type: Array,
@@ -114,6 +115,11 @@ export default {
       default: function() {
         return [];
       }
+    }
+  },
+  computed: {
+    body() {
+      return _.get(this.pageData, "data.attributes.body");
     }
   }
 };

--- a/pages/_slug.vue
+++ b/pages/_slug.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <basic-page
-      :body="$store.state.pageData.data.attributes.body"
+      :page-data="$store.state.pageData"
       :highlighted="$store.state.highlightedData"
       :more="$store.state.relatedContent"
       :extended-content="$store.state.extendedContent"

--- a/pages/audio.vue
+++ b/pages/audio.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <basic-page
-      :body="$store.state.pageData.data.attributes.body"
+      :page-data="$store.state.pageData"
       :highlighted="$store.state.highlightedData"
       :more="$store.state.relatedContent"
       :extended-content="$store.state.extendedContent"

--- a/pages/books.vue
+++ b/pages/books.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <basic-page
-      :body="$store.state.pageData.data.attributes.body"
+      :page-data="$store.state.pageData"
       :highlighted="$store.state.highlightedData"
       :more="$store.state.relatedContent"
       :extended-content="$store.state.extendedContent"

--- a/pages/books/index.vue
+++ b/pages/books/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <basic-page
-      :body="$store.state.pageData.data.attributes.body"
+      :page-data="$store.state.pageData"
       :highlighted="$store.state.highlightedData"
       :more="$store.state.relatedContent"
       :extended-content="$store.state.extendedContent"

--- a/pages/lesson-plans/index.vue
+++ b/pages/lesson-plans/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <basic-page
-      :body="$store.state.pageData.data.attributes.body"
+      :page-data="$store.state.pageData"
       :highlighted="$store.state.highlightedData"
       :more="$store.state.relatedContent"
       :extended-content="$store.state.extendedContent"

--- a/pages/libraries.vue
+++ b/pages/libraries.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <basic-page
-      :body="$store.state.pageData.data.attributes.body"
+      :page-data="$store.state.pageData"
       :highlighted="$store.state.highlightedData"
       :more="$store.state.relatedContent"
       :extended-content="$store.state.extendedContent"

--- a/pages/materials-teachers.vue
+++ b/pages/materials-teachers.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <basic-page
-      :body="$store.state.pageData.data.attributes.body.processed"
+      :page-data="$store.state.pageData"
       :extended-content="$store.state.extendedContent"
       :highlighted="$store.state.highlightedData"
       :call-to-action="callToAction"

--- a/pages/national-poetry-month/poster-request-form.vue
+++ b/pages/national-poetry-month/poster-request-form.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <BasicPage
-      :body="$store.state.pageData.data.attributes.body"
+      :page-data="$store.state.pageData"
       highlighted=""/>
     <b-container>
       <b-row>

--- a/plugins/axios.js
+++ b/plugins/axios.js
@@ -8,6 +8,10 @@ import qs from "qs";
  * @param {Object} store
  */
 export default function({ $axios, redirect }) {
+  $axios.onError(error => {
+    console.table(error);
+    throw error.response;
+  });
   $axios.onRequest(config => {
     config.headers.common["X-Consumer-ID"] = process.env.CONSUMER_ID;
     config.paramsSerializer = params =>

--- a/plugins/poets-api/index.js
+++ b/plugins/poets-api/index.js
@@ -98,7 +98,23 @@ export default ({ app }, inject) => {
             store.commit("updateRelatedContent", {});
           });
       })
-      .catch(error => console.log(error));
+      .catch(error => {
+        console.log(error);
+        store.commit("updateHero", {
+          variant: "quote",
+          lead:
+            "Poetry offers us the capacity to carry in us and express the contradictory impulses that make us human.",
+          subtext: "—Kwame Dawes, Academy of American Poets Chancellor (2018- )"
+        });
+
+        // Set the main page data
+        store.commit("updatePageData", {});
+        store.commit("updateSidebarData", {});
+        store.commit("updateHighlightedData", {});
+        store.commit("updateExtendedContent", {});
+        store.commit("updateFeaturedContent", {});
+        store.commit("updateRelatedContent", {});
+      });
   });
   inject("buildMenu", ({ menu, route, store }) => {
     const transformTree = menu => {

--- a/plugins/poets-api/index.js
+++ b/plugins/poets-api/index.js
@@ -63,42 +63,42 @@ export default ({ app }, inject) => {
       "field_content_sections.side_image.field_image",
       "featured.featured_media.field_image"
     ].join(",");
-    const routerResponse = await app.$axios.$get(
-      `/router/translate-path?path=${path}`
-    );
     return app.$axios
-      .$get(`${routerResponse.jsonapi.individual}?include=${includes}`)
-      .then(response => {
-        let page = response;
-        if (page.data.attributes.body !== null) {
-          page.data.attributes.body.processed = imgUrl.staticUrl(
-            page.data.attributes.body.processed
-          );
-        }
+      .$get(`/router/translate-path?path=${path}`)
+      .then(routerResponse => {
+        return app.$axios
+          .$get(`${routerResponse.jsonapi.individual}?include=${includes}`)
+          .then(response => {
+            let page = response;
+            if (_.get(page, "data.attributes.body.processed")) {
+              page.data.attributes.body.processed = imgUrl.staticUrl(
+                page.data.attributes.body.processed
+              );
+            }
 
-        store.commit("updateHero", {
-          variant: "default",
-          heading: page.data.attributes.title,
-          lead: page.data.attributes.hasOwnProperty("lead_text")
-            ? page.data.attributes.lead_text
-            : null
-        });
-        // Set the main page data
-        store.commit("updatePageData", page);
-        const sidebarData = sections.buildSidebar(page);
-        store.commit("updateSidebarData", sidebarData);
-        // Handle the content in the 'highlighted' area.
-        const highlightedData = sections.buildHighlightedData(page);
-        store.commit("updateHighlightedData", highlightedData);
-        const extendedContent = sections.buildExtendedContentSection(page);
-        store.commit("updateExtendedContent", extendedContent);
-        const featuredContent = sections.buildFeaturedContentSection(page);
-        store.commit("updateFeaturedContent", featuredContent);
-        // Right now we don't have a field for related content, but pages
-        // May occasionally stick stuff there and we don't want it to bleed.
-        // Make sure you call the additional changes AFTER this function.
-        store.commit("updateRelatedContent", {});
-      });
+            store.commit("updateHero", {
+              variant: "default",
+              heading: _.get(page, "data.attributes.title"),
+              lead: _.get(page, "data.attributes.lead_text")
+            });
+            // Set the main page data
+            store.commit("updatePageData", page);
+            const sidebarData = sections.buildSidebar(page);
+            store.commit("updateSidebarData", sidebarData);
+            // Handle the content in the 'highlighted' area.
+            const highlightedData = sections.buildHighlightedData(page);
+            store.commit("updateHighlightedData", highlightedData);
+            const extendedContent = sections.buildExtendedContentSection(page);
+            store.commit("updateExtendedContent", extendedContent);
+            const featuredContent = sections.buildFeaturedContentSection(page);
+            store.commit("updateFeaturedContent", featuredContent);
+            // Right now we don't have a field for related content, but pages
+            // May occasionally stick stuff there and we don't want it to bleed.
+            // Make sure you call the additional changes AFTER this function.
+            store.commit("updateRelatedContent", {});
+          });
+      })
+      .catch(error => console.log(error));
   });
   inject("buildMenu", ({ menu, route, store }) => {
     const transformTree = menu => {


### PR DESCRIPTION
@pirog @labboy0276 @dbungard this should soften the blow when we've moved pages around on the backend. Instead of server errors we should now get pages that are devoid of content from the node. This means any page that combines a node with some listings will gracefully show it's listings without tanking because the node is missing.

To verify the experience, try going to the deleted /materials-teachers/poems-kids route and see that you get an empty page rather than an error. Then check out /lesson-plans, /audio, /video, etc. Any page that would have completely tanked previously is now going to render a generic hero and the non-node content of the page (lists of items, etc)