### PR TITLE
thinktandem/poets-api#350: Fix issue with sidebar_text_and_image that…

### DIFF
--- a/plugins/poets-api/lib/util.js
+++ b/plugins/poets-api/lib/util.js
@@ -43,7 +43,7 @@ export default {
   },
 
   firstOrOnly(data) {
-    if (data.constructor === Array) {
+    if (_.isArray(data)) {
       return _.first(data);
     } else {
       return data;
@@ -100,15 +100,22 @@ export default {
   maybeField(entity, field) {
     return entity.hasOwnProperty("attributes") &&
       entity.attributes.hasOwnProperty(field) &&
-      entity.attributes[field] !== null
+      !_.isEmpty(entity.attributes[field])
       ? entity.attributes[field]
-      : null;
+      : false;
   },
 
   buildProcessable(entity, field = "body", summary = false) {
-    return this.maybeField(entity, field) !== null
-      ? imgUrl.staticUrl(this.maybeField(entity, field).processed)
-      : null;
+    const maybeField = this.maybeField(entity, field);
+    if (maybeField) {
+      return _.isArray(maybeField) && maybeField.length > 0
+        ? _.map(maybeField, function(value) {
+            return imgUrl.staticUrl(value.processed);
+          })
+        : imgUrl.staticUrl(maybeField.processed);
+    } else {
+      return null;
+    }
   },
 
   buildFile(entity, page) {


### PR DESCRIPTION
… borks most (all?) Basic Pages.

FROM SLACK: Noticed that we weren't handling sidebar_text fields when processing them for images (we weren't accounting for that data being an array of objects that all need to be processed); if someone could please review this PR so we can merge that it in, seems like that issue was nuking most of the default rendered Basic Pages.

FYI, I think my solution is pretty fugly, so would appreciate a true CODE POET.

ALSO, **PLEASE USE FUCKING LODASH!!!**; checking things like `somevalue.constructor === Array` can cause unexpected failures that `_.isArray(somevalue)` will avoid.